### PR TITLE
add `init_logger()` function

### DIFF
--- a/src/externs.h
+++ b/src/externs.h
@@ -904,6 +904,7 @@ extern char* squelch_to_label(int squelch);
 extern bool use_object(object_type* o_ptr, bool* ident);
 
 /* util.c */
+extern void init_logger(bool quiet);
 extern errr path_parse(char* buf, size_t max, cptr file);
 extern errr path_build(char* buf, size_t max, cptr path, cptr file);
 extern FILE* my_fopen(cptr file, cptr mode);

--- a/src/log.c
+++ b/src/log.c
@@ -166,3 +166,13 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
 
   unlock();
 }
+
+void log_close_files()
+{
+    for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++) {
+        if (L.callbacks[i].fn == file_callback) {
+            fclose((FILE*)L.callbacks[i].udata);
+            L.callbacks[i] = (Callback){0};
+        }
+    }
+}

--- a/src/log.h
+++ b/src/log.h
@@ -43,6 +43,7 @@ void log_set_level(int level);
 void log_set_quiet(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);
+void log_close_files();
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);
 

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3909,7 +3909,6 @@ static void init_stuff(void)
 	validate_dir(ANGBAND_DIR_XTRA_HELP);
 #endif /* 0 */
 }
-// FILE *log_file;
 
 int FAR PASCAL WinMain(
     HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine, int nCmdShow)
@@ -3919,37 +3918,9 @@ int FAR PASCAL WinMain(
     WNDCLASS wc;
     HDC hdc;
 
-        use_background_colors = true;
+    use_background_colors = true;
 
-        //Logging initialization
-        const char* log_level_str = getenv("SIL_LOG_LEVEL");
-        log_set_level(LOG_INFO);
-        if (log_level_str)
-        {
-            for (int i = LOG_TRACE; i <= LOG_FATAL; i++)
-            {
-                if (strcmp(log_level_str, log_level_string(i)) == 0)
-                {
-                    log_set_level(i);
-                    goto LOG_LEVEL_SET;
-                }
-            }
-            log_warn("Unknown log level %s, log level will be set to INFO",
-                log_level_str);
-        }
-  
-    // Open log file in current working directory (create if necessary)
-    log_debug("Attempting to open log file: log.txt");
-    FILE* log_file = fopen("log.txt", "w");
-    if (log_file) {
-        log_debug("Successfully opened log file: log.txt");
-        log_add_fp(log_file, LOG_DEBUG);
-    } else {
-        log_debug("Failed to open log file: log.txt");
-    }
-    LOG_LEVEL_SET:
-
-        log_info("logger initialised");
+    init_logger(false);
 
     // Sil-y: commented this out
     // MSG msg;

--- a/src/main.c
+++ b/src/main.c
@@ -402,24 +402,8 @@ int main(int argc, char* argv[])
     player_uid += (getgid() * 1000);
 #endif /* VMS */
 
-    const char* log_level_str = getenv("SIL_LOG_LEVEL");
-    log_set_level(LOG_INFO);
-    if (log_level_str)
-    {
-        for (int i = LOG_TRACE; i <= LOG_FATAL; i++)
-        {
-            if (strcmp(log_level_str, log_level_string(i)) == 0)
-            {
-                log_set_level(i);
-                goto LOG_LEVEL_SET;
-            }
-        }
-        log_warn("Unknown log level %s, log level will be set to INFO",
-            log_level_str);
-    }
-LOG_LEVEL_SET:
-
-    log_info("logger initialised");
+// Initialise logger in 'quiet' mode (don't write to stdout).
+init_logger(true);
 
 #ifdef SAFE_SETUID
 

--- a/src/util.c
+++ b/src/util.c
@@ -5257,3 +5257,45 @@ cptr attr_to_text(byte a)
 
     return (base);
 }
+
+/*
+ * Initialises logger. Opens `log.txt` file and sets log level for stdout and
+ * file from `SIL_LOG_LEVEL` environment variable. The `quiet` argument disables
+ * stdout when set to true (essential for terminal modes like ncurses where
+ * screen output would be garbled otherwise).
+ */
+void init_logger(bool quiet)
+{
+    const char* log_level_str = getenv("SIL_LOG_LEVEL");
+    int level = LOG_INFO;
+    if (log_level_str)
+    {
+        for (level = LOG_TRACE; level <= LOG_FATAL; level++)
+        {
+            if (strcmp(log_level_str, log_level_string(level)) == 0)
+            {
+                break;
+            }
+        }
+        if (level > LOG_FATAL)
+        {
+            level = LOG_INFO;
+            log_warn("Unknown log level %s, log level will be set to INFO",
+                log_level_str);
+        }
+    }
+
+    FILE* log_file = my_fopen("log.txt", "w");
+    if (!log_file)
+        quit("could not open log.txt for writing");
+    log_add_fp(log_file, level);
+    log_set_level(level);
+
+    if (quiet)
+    {
+        log_set_quiet(true);
+    }
+
+    log_info("logger initialised");
+    atexit(log_close_files);
+}


### PR DESCRIPTION
Initialises and de-initialises logger. For Windows, also writes to the terminal. For other systems, writes to the file only.