### PR TITLE
Handle metarun death narrative allocation failure

### DIFF
--- a/src/metarun.c
+++ b/src/metarun.c
@@ -1482,8 +1482,16 @@ void metarun_update_on_exit(bool died, bool escaped, byte sil_count)
         byte target_order = has_gift_eru ? 0 : metar.deaths;
 
         /* Build a pool of candidate story entries.                    */
-        int pool[z_info->st_max], pool_sz = 0;
-        for (int i = 0; i < z_info->st_max; i++) {
+        int *pool = C_ZNEW(z_info->st_max, int);
+        int pool_sz = 0;
+        if (!pool) {
+            screen_load();                 /* restore game view            */
+            check_run_end();
+            save_metaruns();
+            FREE(pool);
+            return;
+        }
+        for (int i = 0; i < z_info->st_max && pool; i++) {
             story_type *st = &st_info[i];
             if (!st->name)            continue;                /* unused slot   */
             if (st->st_type != 1)     continue;                /* not “death”   */
@@ -1495,7 +1503,7 @@ void metarun_update_on_exit(bool died, bool escaped, byte sil_count)
 
         /* Fallback – allow any order-0 message if nothing matched.   */
         if (!pool_sz && target_order) {
-            for (int i = 0; i < z_info->st_max; i++) {
+            for (int i = 0; i < z_info->st_max && pool; i++) {
                 story_type *st = &st_info[i];
                 if (!st->name || st->st_type != 1) continue;
                 if (st->order != 0)   continue;
@@ -1513,12 +1521,12 @@ void metarun_update_on_exit(bool died, bool escaped, byte sil_count)
 
             print_heading_fade(title, TERM_RED);
             print_paragraph_fade(text, TERM_WHITE, 4);
-            
+
             char transition_text[256];
             strnfmt(transition_text, sizeof(transition_text),
                     "The hero whose mantle you took has fallen, their tale ends in shadow. "
                     "Yet your spirit returns, for the Valar's trial is not yet complete.");
-            
+
             if (!fast_forward && !print_paragraph_fade(transition_text, TERM_L_BLUE, 8))
                 fast_forward = true;
             else if (fast_forward)
@@ -1527,6 +1535,7 @@ void metarun_update_on_exit(bool died, bool escaped, byte sil_count)
         }
 
         screen_load();                 /* restore game view            */
+        FREE(pool);
         check_run_end();
         save_metaruns();
         return;


### PR DESCRIPTION
## Summary
- switch the death narrative pool in `metarun_update_on_exit()` to dynamic allocation with a null guard
- ensure both selection loops check for a valid pool pointer before populating
- release the buffer before every return from the death branch to avoid leaks

## Testing
- `make -f Makefile.cyg -j8`
- `msbuild ../msvc2022/Sil.sln /p:Configuration=Release /m`


------
https://chatgpt.com/codex/tasks/task_b_68dad40d7d3c832b8c41d5ca7c368eb3