### PR TITLE
Fix savefile ordering for oath persistence

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -61,7 +61,7 @@
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 8
 #define VERSION_PATCH 9
-#define VERSION_EXTRA 2
+#define VERSION_EXTRA 3
 
 /*
  * Oldest version number that can still be imported

--- a/src/load.c
+++ b/src/load.c
@@ -1099,16 +1099,58 @@ static errr rd_extra(void)
     /* Current turn */
     rd_s32b(&turn);
 
-    /* Current player turn */
-    rd_s32b(&playerturn);
-    
-    /* New shatter flags - read from end for save compatibility */
-    /* Old saves won't have these, so default to 0 */
-    if (!older_than(1, 5, 1)) {  /* Only read if save is new enough */
+    /* Player turn / crown shatter flags changed layout across sf_extra revisions */
+    if (sf_extra >= 3)
+    {
+        /* New format: playerturn stored immediately after turn, then shatter flags */
+        rd_s32b(&playerturn);
         rd_byte(&p_ptr->crown_shatter_sil2);
         rd_byte(&p_ptr->crown_shatter_sil3);
     }
-    else {
+    else if (sf_extra == 2)
+    {
+        /* Legacy 0.8.9.x saves wrote shatter flags first and duplicated the turn */
+        rd_byte(&p_ptr->crown_shatter_sil2);
+        rd_byte(&p_ptr->crown_shatter_sil3);
+
+        s32b turn_repeat = 0;
+        rd_s32b(&turn_repeat);
+        if (turn_repeat == turn)
+        {
+            rd_s32b(&playerturn);
+        }
+        else
+        {
+            /* No duplicate present (unexpected but recoverable) */
+            playerturn = turn_repeat;
+
+            long rewind_pos = ftell(fff);
+            u32b saved_v_check = v_check, saved_x_check = x_check, saved_offset = load_byte_offset;
+            byte saved_xor = xor_byte;
+
+            s32b maybe_playerturn = 0;
+            rd_s32b(&maybe_playerturn);
+            if (maybe_playerturn != playerturn)
+            {
+                /* Not an echoed player turn, restore stream state */
+                fseek(fff, rewind_pos, SEEK_SET);
+                v_check = saved_v_check;
+                x_check = saved_x_check;
+                load_byte_offset = saved_offset;
+                xor_byte = saved_xor;
+            }
+        }
+    }
+    else
+    {
+        /* Very old saves: playerturn present but no shatter flags */
+        rd_s32b(&playerturn);
+        p_ptr->crown_shatter_sil2 = 0;
+        p_ptr->crown_shatter_sil3 = 0;
+    }
+
+    if (sf_extra < 2)
+    {
         p_ptr->crown_shatter_sil2 = 0;
         p_ptr->crown_shatter_sil3 = 0;
     }

--- a/src/save.c
+++ b/src/save.c
@@ -967,14 +967,15 @@ static void wr_extra(void)
 
     /* Current turn */
     wr_s32b(turn);
-
-    /* New shatter flags - added at end for save compatibility */
-    wr_byte(p_ptr->crown_shatter_sil2);
-    wr_byte(p_ptr->crown_shatter_sil3);
-    wr_s32b(turn);
     log_trace("Current turn: %d", turn);
+
+    /* Current player turn */
     wr_s32b(playerturn);
     log_trace("Player turn: %d", playerturn);
+
+    /* Crown shatter flags (Sil 2 / Sil 3) */
+    wr_byte(p_ptr->crown_shatter_sil2);
+    wr_byte(p_ptr->crown_shatter_sil3);
 
     wr_byte(p_ptr->killed_enemy_with_arrow ? 1 : 0);
 


### PR DESCRIPTION
## Summary
- write turn, player turn, and crown shatter flags in the order the loader expects to keep oath data aligned
- update the loader to recognise legacy saves with the duplicate turn value and to consume the new format when `sf_extra >= 3`
- bump `VERSION_EXTRA` so freshly written saves advertise the corrected layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e8590d982c832b9c6db365333a452f