### PR TITLE
Fix build on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ if(USE_SDL)
   find_package(SDL3_ttf REQUIRED CONFIG)
   find_package(SDL3_image REQUIRED CONFIG)
   target_compile_definitions(sil-more PRIVATE USE_SDL)
-  target_link_libraries(sil-more PRIVATE SDL3::SDL3 SDL3_ttf::SDL3_ttf SDL3_image::SDL3_image log)
+  target_link_libraries(sil-more PRIVATE SDL3::SDL3 SDL3_ttf::SDL3_ttf SDL3_image::SDL3_image log m)
 endif()
 
 if(USE_GCU)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Secondly, it uses a system of metaruns, where consequtive runs are connected int
      ```
    - **Arch:**
      ```bash
-     sudo pacman -S base-devel cmake sdl3 sdl3-image sdl3-ttf
+     sudo pacman -S base-devel cmake sdl3
+     paru -S sdl3_ttf sdl3_image # or use any other AUR helper
      ```
 
 2. Navigate to the Sil-More source directory.

--- a/src/files.c
+++ b/src/files.c
@@ -8,6 +8,11 @@
  * are included in all such copies.  Other copyrights may also apply.
  */
 
+#ifndef WINDOWS
+#define _DEFAULT_SOURCE  /* For DT_DIR and other POSIX extensions */
+#define _BSD_SOURCE      /* For setregid on older systems */
+#endif
+
 #include "angband.h"
 #include "h-basic.h"
 #include "metarun.h"
@@ -25,8 +30,6 @@
 #include <windows.h>
 #include <direct.h>  /* For _mkdir */
 #else
-#define _DEFAULT_SOURCE  /* For DT_DIR and other POSIX extensions */
-#define _BSD_SOURCE      /* For setregid on older systems */
 #include <sys/stat.h>  /* For mkdir */
 #include <dirent.h>    /* For directory operations */
 #include <unistd.h>    /* For setregid, getgid, etc. */

--- a/src/metarun.c
+++ b/src/metarun.c
@@ -7,6 +7,12 @@
  *     • list_metaruns()  – compact history view
  *     • print_metarun_stats() – details for current run
  * -------------------------------------------------------------------- */
+
+#ifndef WINDOWS
+#define _DEFAULT_SOURCE  /* For DT_DIR and other POSIX extensions */
+#define _BSD_SOURCE      /* For setregid on older systems */
+#endif
+
 #include "angband.h"
 #include "metarun.h"
 #include "h-define.h"


### PR DESCRIPTION
Changes in db0f3da did not fix it for me, but sent me in the right direction. The `#define` must have gone higher, because `unistd.h` is also required in `platform.h`.

Additionally, linker was failing on missing `libm` 

```
/usr/bin/ld: CMakeFiles/sil-more.dir/src/cmd1.c.o: undefined reference to symbol 'pow@@GLIBC_2.29'
```

Fixes #17 